### PR TITLE
Import SymbolicIndexingInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
 [compat]
 Distributions = "0.21.10, 0.22, 0.23, 0.24, 0.25"
@@ -39,6 +40,7 @@ SimpleNonlinearSolve = "0.1.2"
 StaticArrays = "<0.13, 1"
 StatsAPI = "1.5"
 StatsBase = "0.29,0.30,0.32, 0.33"
+SymbolicIndexingInterface = "0.2"
 julia = "1.7"
 
 [extras]

--- a/src/LowLevelParticleFilters.jl
+++ b/src/LowLevelParticleFilters.jl
@@ -17,6 +17,7 @@ using RecipesBase
 using ForwardDiff
 using SimpleNonlinearSolve
 using Polyester
+using SymbolicIndexingInterface
 
 using SciMLBase
 

--- a/src/PFtypes.jl
+++ b/src/PFtypes.jl
@@ -1,7 +1,7 @@
 
 abstract type AbstractParticleFilter <: AbstractFilter end
 
-import SciMLBase.SymbolicIndexingInterface: parameters
+import SymbolicIndexingInterface: parameters
 
 function parameters(f::AbstractFilter)
     hasproperty(f, :p) ? getproperty(f, :p) : SciMLBase.NullParameters()


### PR DESCRIPTION
- SciMLBase doesn't re-export SymbolicIndexingInterface anymore

```
ERROR: LoadError: UndefVarError: SymbolicIndexingInterface not defined
Stacktrace:
 [1] include(mod::Module, _path::String)
   @ Base ./Base.jl:418
 [2] include(x::String)
   @ LowLevelParticleFilters /home/vkb/.julia/packages/LowLevelParticleFilters/neZRi/src/LowLevelParticleFilters.jl:1
 [3] top-level scope
   @ /home/vkb/.julia/packages/LowLevelParticleFilters/neZRi/src/LowLevelParticleFilters.jl:28
 [4] include
   @ ./Base.jl:418 [inlined]
 [5] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::String)
   @ Base ./loading.jl:1318
 [6] top-level scope
   @ none:1
 [7] eval
   @ ./boot.jl:373 [inlined]
 [8] eval(x::Expr)
   @ Base.MainInclude ./client.jl:453
 [9] top-level scope
   @ none:1
in expression starting at /home/vkb/.julia/packages/LowLevelParticleFilters/neZRi/src/PFtypes.jl:4
in expression starting at /home/vkb/.julia/packages/LowLevelParticleFilters/neZRi/src/LowLevelParticleFilters.jl:1
```