### PR TITLE
add option to sample to get initial point

### DIFF
--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -323,15 +323,19 @@ Simulate dynamical system forward in time `T` steps, or for the duration of `u`,
 
 If [MonteCarloMeasurements.jl](https://github.com/baggepinnen/MonteCarloMeasurements.jl) is loaded, the argument `N::Int` can be supplied, in which case `N` simulations are done and the result is returned in the form of `Vector{MonteCarloMeasurements.Particles}`.
 """
-function simulate(f::AbstractFilter, T::Int, du::Distribution, p=parameters(f); dynamics_noise=true, measurement_noise=true)
+function simulate(f::AbstractFilter, T::Int, du::Distribution, p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initially=false)
     u = [rand(du) for t=1:T]
-    simulate(f, u, p; dynamics_noise, measurement_noise)
+    simulate(f, u, p; dynamics_noise, measurement_noise, sample_initially)
 end
 
-function simulate(f::AbstractFilter,u,p=parameters(f); dynamics_noise=true, measurement_noise=true)
+function simulate(f::AbstractFilter,u,p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initially=false)
     y = similar(u)
     x = similar(u)
-    x[1] = sample_state(f, p; noise=false)
+    if sample_initially
+        x[1] = sample_state(f, p; noise=true)
+    else
+        x[1] = sample_state(f, p; noise=false)
+    end
     T = length(u)
     for t = 1:T-1
         y[t] = sample_measurement(f,x[t], u[t], p, t; noise=measurement_noise)

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -328,14 +328,10 @@ function simulate(f::AbstractFilter, T::Int, du::Distribution, p=parameters(f); 
     simulate(f, u, p; dynamics_noise, measurement_noise, sample_initially)
 end
 
-function simulate(f::AbstractFilter,u,p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initially=false)
+function simulate(f::AbstractFilter,u,p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initial=false)
     y = similar(u)
     x = similar(u)
-    if sample_initially
-        x[1] = sample_state(f, p; noise=true)
-    else
-        x[1] = sample_state(f, p; noise=false)
-    end
+    x[1] = sample_state(f, p; noise=sample_initial)
     T = length(u)
     for t = 1:T-1
         y[t] = sample_measurement(f,x[t], u[t], p, t; noise=measurement_noise)

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -323,9 +323,9 @@ Simulate dynamical system forward in time `T` steps, or for the duration of `u`,
 
 If [MonteCarloMeasurements.jl](https://github.com/baggepinnen/MonteCarloMeasurements.jl) is loaded, the argument `N::Int` can be supplied, in which case `N` simulations are done and the result is returned in the form of `Vector{MonteCarloMeasurements.Particles}`.
 """
-function simulate(f::AbstractFilter, T::Int, du::Distribution, p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initially=false)
+function simulate(f::AbstractFilter, T::Int, du::Distribution, p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initial=false)
     u = [rand(du) for t=1:T]
-    simulate(f, u, p; dynamics_noise, measurement_noise, sample_initially)
+    simulate(f, u, p; dynamics_noise, measurement_noise, sample_initial)
 end
 
 function simulate(f::AbstractFilter,u,p=parameters(f); dynamics_noise=true, measurement_noise=true, sample_initial=false)


### PR DESCRIPTION
When working with complex state distributions (mixed discrete/continuous) I ran into a problem trying to simulate from the AdvancedParticleFilter, because the initial point is per default the mean of the distribution. 
Generally, the mean of a distribution (even a continuous one) is never guaranteed to be in the support of the distribution. Hence, providing the user the choice to sample instead of taking the mean of the distribution to get an initial distribution for the particle filter would be beneficial. Especially since this barely changes the code. 