### PR TITLE
Fix indexing error in particle resampling

### DIFF
--- a/src/mcm.jl
+++ b/src/mcm.jl
@@ -21,7 +21,7 @@ function MonteCarloMeasurements.Particles(x::AbstractMatrix{<:AbstractVector},we
     ## Perform resampling so that all particles have the same weight
     choices = map(LowLevelParticleFilters.resample, eachcol(we))
     for j in 1:size(xp,2), i in 1:size(xp,1)
-        xp[i,j].particles .= xp[i,j].particles[choices[j]]
+        xp[i,j].particles .= xp[i,j].particles[choices[i]]
     end
     xp
 end


### PR DESCRIPTION
`xp` has size `n_observations, length(x)`. The resampling returns a vector of length `n_observations`, with each element contain `length(x)` indices. I think the index of `choices` in Line 24 should be `i`, not `j`, to avoid a BoundsError if `length(x) > n_observations`. But please double check that this is correct. It's just my best guess how to fix an error I kept getting for very long state vectors.

Not-so-MWE:
```
using LowLevelParticleFilters, MonteCarloMeasurements, Distributions

dynamics_noise = MvNormal(30,.1)
measurement_noise = MvNormal(30,.1)
rng = Random.Xoshiro()

function dynamics(x,u,p,t,noise=false)
  if noise
    return x .+ rand(rng,dynamics_noise)
  else
    return x
  end
end

function measurement(x,u,p,t,noise=false)
  if noise
    return x .+ rand(rng,measurement_noise)
  else
    return x
  end
end

function measurement_likelihood(x,u,y,p,t)
  logpdf(measurement_noise, x .- y)
end
state_init = MvNormal(30,.1)

apf = AdvancedParticleFilter(50,dynamics,measurement, measurement_likelihood,nothing,state_init)

sol = forward_trajectory(apf, zeros(5), [ones(30) for i=1:5], nothing)

Particles(sol.x,sol.we) #BoundsError
```