### PR TITLE
add tests for differentiability

### DIFF
--- a/src/ekf.jl
+++ b/src/ekf.jl
@@ -28,6 +28,7 @@ ExtendedKalmanFilter
 
 function ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=MvNormal(Matrix(R1)); nu::Int, p = SciMLBase.NullParameters(), α = 1.0, check = true)
     nx = size(R1,1)
+    ny = size(R2,1)
     T = eltype(R1)
     if R1 isa SMatrix
         x = @SVector zeros(T, nx)
@@ -40,7 +41,7 @@ function ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=MvNormal(Matrix(R1
     A = ForwardDiff.jacobian(x->dynamics(x,u,p,t), x)
     B = ForwardDiff.jacobian(u->dynamics(x,u,p,t), u)
     C = ForwardDiff.jacobian(x->measurement(x,u,p,t), x)
-    D = ForwardDiff.jacobian(u->measurement(x,u,p,t), u)
+    D = zeros(ny, nu) # This one is never needed
     kf = KalmanFilter(A,B,C,D,R1,R2,d0; p, α, check)
     return ExtendedKalmanFilter(kf, dynamics, measurement)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -267,6 +267,11 @@ end
     include("test_jet.jl")
 end
 
+@testset "diff" begin
+    @info "Testing diff"
+    include("test_diff.jl")
+end
+
 
 @testset "Advanced filters" begin
     @info "testing Advanced filters"

--- a/test/test_diff.jl
+++ b/test/test_diff.jl
@@ -1,0 +1,105 @@
+using LowLevelParticleFilters
+using Test, Random, LinearAlgebra, Statistics, StaticArrays, Distributions
+using ForwardDiff
+Random.seed!(0)
+tosvec(y) = reinterpret(SVector{length(y[1]),Float64}, reduce(hcat,y))[:] |> copy
+
+
+## KF
+
+eye(n) = SMatrix{n,n}(Matrix{Float64}(I,n,n))
+nx = 2 # Dinemsion of state
+nu = 2 # Dinemsion of input
+ny = 2 # Dinemsion of measurements
+
+d0 = MvNormal(@SVector(randn(nx)),2.0)   # Initial state Distribution
+du = MvNormal(2,1) # Control input distribution
+
+# Define linenar state-space system
+const _A = SA[0.99 0.1; 0 0.2]
+const _B = @SMatrix [-0.7400216956683083 1.6097265310456392; -1.4384539113366408 1.7467811974822818]
+const _C = SMatrix{ny,ny}(eye(ny))
+# C = SMatrix{p,n}([1 1])
+
+dynamics(x,u,p,t) = _A*x .+ _B*u
+measurement(x,u,p,t) = _C*x
+
+T    = 200 # Number of time steps
+kf   = KalmanFilter(_A, _B, _C, 0, eye(nx), eye(ny), d0)
+x,u,y = LowLevelParticleFilters.simulate(kf,T,du) # Simuate trajectory using the model in the filter
+x,u,y = tosvec.((x,u,y))
+
+
+# Test differentiability w.r.t. R1
+function costfun1(p::AbstractArray{T}) where T
+    R1 = p[1]*eye(nx)
+
+    d0 = MvNormal(@SVector(zeros(T, nx)),T(1.0))   # Initial state Distribution
+
+    ukf = UnscentedKalmanFilter(dynamics, measurement, R1, eye(ny), d0; ny, nu)
+    skf = SqKalmanFilter(_A, _B, _C, 0, R1, eye(ny), d0)
+    ekf = ExtendedKalmanFilter(dynamics, measurement, R1, eye(ny), d0; nu, check=false)
+
+    filters = [kf, ukf, skf, ekf]
+    out = zero(T)
+    for filter in filters
+        predict!(filter, u[1])
+        (; ll, e) = correct!(filter, u[1], y[1])
+        out -= ll
+        out += sum(e)
+    end
+    out
+end
+
+@test_nowarn ForwardDiff.gradient(costfun1, [1.0])
+
+# Test differentiability w.r.t. R2
+function costfun2(p::AbstractArray{T}) where T
+    R1 = eye(nx)
+    R2 = p[1]*eye(ny)
+
+    d0 = MvNormal(@SVector(zeros(T, nx)),T(1.0))   # Initial state Distribution
+
+    ukf = UnscentedKalmanFilter(dynamics, measurement, R1, R2, d0; ny, nu)
+    skf = SqKalmanFilter(_A, _B, _C, 0, R1, R2, d0)
+    ekf = ExtendedKalmanFilter(dynamics, measurement, R1, R2, d0; nu, check=false)
+
+    filters = [kf, ukf, skf, ekf]
+    out = zero(T)
+    for filter in filters
+        predict!(filter, u[1])
+        (; ll, e) = correct!(filter, u[1], y[1])
+        out -= ll
+        out += sum(e)
+    end
+    out
+end
+
+@test_nowarn ForwardDiff.gradient(costfun2, [1.0])
+
+## Test differentiability w.r.t. p in dynamics
+
+dynamics3(x,u,p,t) = _A*x .+ _B*u .+ p
+measurement3(x,u,p,t) = _C*x .+ p
+
+function costfun3(p::AbstractArray{T}) where T
+    R1 = eye(nx)
+    R2 = eye(ny)
+
+    d0 = MvNormal(@SVector(zeros(T, nx)),T(1.0))   # Initial state Distribution
+
+    ukf = UnscentedKalmanFilter(dynamics3, measurement3, R1, R2, d0; ny, nu, p)
+    ekf = ExtendedKalmanFilter(dynamics3, measurement3, R1, R2, d0; nu, check=false, p)
+
+    filters = [kf, ukf, skf, ekf]
+    out = zero(T)
+    for filter in filters
+        predict!(filter, u[1])
+        (; ll, e) = correct!(filter, u[1], y[1])
+        out -= ll
+        out += sum(e)
+    end
+    out
+end
+
+@test_nowarn ForwardDiff.gradient(costfun3, [0.0])


### PR DESCRIPTION
This PR adds tests to make sure all Kalman filters are differentiable w.r.t.
- `R1`
- `R2`
- `p` in the dynamics

The important thing to ensure that filters are differentiable is to let the initial state distribution `d0` have the correct element type, e.g., something like
```julia
function costfun1(p::AbstractArray{T}) where T
    d0 = MvNormal(@SVector(zeros(T, nx)), T(1.0))   # Initial state Distribution with correct element type
    # construct filter
    ...
end
```