### PR TITLE
accept user-defined jacobians in EKF

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -29,7 +29,7 @@ Depending on the nature of ``f`` and ``g``, the best method of estimating the st
 We provide a number of filter types
 - [`KalmanFilter`](@ref). A standard Kalman filter. Is restricted to linear dynamics (possibly time varying) and Gaussian noise.
 - [`SqKalmanFilter`](@ref). A standard Kalman filter on square-root form (slightly slower but more numerically stable with ill-conditioned covariance).
-- [`ExtendedKalmanFilter`](@ref): For nonlinear systems, the EKF runs a regular Kalman filter on linearized dynamics. Uses ForwardDiff.jl for linearization. The noise model must be Gaussian.
+- [`ExtendedKalmanFilter`](@ref): For nonlinear systems, the EKF runs a regular Kalman filter on linearized dynamics. Uses ForwardDiff.jl for linearization (or user provided). The noise model must be Gaussian.
 - [`UnscentedKalmanFilter`](@ref): The Unscented Kalman filter often performs slightly better than the Extended Kalman filter but may be slightly more computationally expensive. The UKF handles nonlinear dynamics and measurement models, but still requires a Gaussian noise model (may be non additive) and assumes all posterior distributions are Gaussian, i.e., can not handle multi-modal posteriors.
 - [`ParticleFilter`](@ref): The particle filter is a nonlinear estimator. This version of the particle filter is simple to use and assumes that both dynamics noise and measurement noise are additive. Particle filters handle multi-modal posteriors.
 - [`AdvancedParticleFilter`](@ref): This filter gives you more flexibility, at the expense of having to define a few more functions. This filter does not require the noise to be additive and is thus the most flexible filter type.
@@ -230,12 +230,12 @@ ukf = UnscentedKalmanFilter(dynamics, measurement, cov(df), cov(dg), MvNormal(SA
 
 
 # Extended Kalman Filter
-The [`ExtendedKalmanFilter`](@ref) ([EKF](https://en.wikipedia.org/wiki/Extended_Kalman_filter)) is similar to the UKF, but propagates Gaussian distributions by linearizing the dynamics and using the formulas for linear systems similar to the standard Kalman filter. This can be slightly faster than the UKF (not always), but also less accurate for strongly nonlinear systems. The linearization is performed automatically using ForwardDiff.jl. In general, the UKF is recommended over the EKF unless the EKF is faster and computational performance is the top priority.
+The [`ExtendedKalmanFilter`](@ref) ([EKF](https://en.wikipedia.org/wiki/Extended_Kalman_filter)) is similar to the UKF, but propagates Gaussian distributions by linearizing the dynamics and using the formulas for linear systems similar to the standard Kalman filter. This can be slightly faster than the UKF (not always), but also less accurate for strongly nonlinear systems. The linearization is performed automatically using ForwardDiff.jl unless the user provides Jacobian functions that compute ``A`` and ``C``. In general, the UKF is recommended over the EKF unless the EKF is faster and computational performance is the top priority.
 
 The EKF constructor has the following two signatures
 ```julia
-ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=MvNormal(R1); nu::Int, p = LowLevelParticleFilters.NullParameters(), α = 1.0, check = true)
-ExtendedKalmanFilter(kf, dynamics, measurement)
+ExtendedKalmanFilter(dynamics, measurement, R1, R2, d0=MvNormal(R1); nu::Int, p = LowLevelParticleFilters.NullParameters(), α = 1.0, check = true, Ajac = nothing, Cjac = nothing)
+ExtendedKalmanFilter(kf, dynamics, measurement; Ajac = nothing, Cjac = nothing)
 ```
 The first constructor takes all the arguments required to initialize the extended Kalman filter, while the second one takes an already defined standard Kalman filter. using the first constructor, the user must provide the number of inputs to the system, `nu`.
 

--- a/src/ekf.jl
+++ b/src/ekf.jl
@@ -1,8 +1,10 @@
 abstract type AbstractExtendedKalmanFilter <: AbstractKalmanFilter end
-@with_kw struct ExtendedKalmanFilter{KF <: KalmanFilter, F, G} <: AbstractExtendedKalmanFilter
+@with_kw struct ExtendedKalmanFilter{KF <: KalmanFilter, F, G, A, C} <: AbstractExtendedKalmanFilter
     kf::KF
     dynamics::F
     measurement::G
+    Ajac::A
+    Cjac::C
 end
 
 """
@@ -26,7 +28,7 @@ See also [`UnscentedKalmanFilter`](@ref) which is typically more accurate than `
 """
 ExtendedKalmanFilter
 
-function ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=SimpleMvNormal(Matrix(R1)); nu::Int, p = NullParameters(), α = 1.0, check = true)
+function ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=SimpleMvNormal(Matrix(R1)); nu::Int, p = NullParameters(), α = 1.0, check = true, Ajac = nothing, Cjac = nothing)
     nx = size(R1,1)
     ny = size(R2,1)
     T = eltype(R1)
@@ -38,12 +40,28 @@ function ExtendedKalmanFilter(dynamics, measurement, R1,R2,d0=SimpleMvNormal(Mat
         u = zeros(T, nu)
     end
     t = one(T)
-    A = ForwardDiff.jacobian(x->dynamics(x,u,p,t), x)
-    B = ForwardDiff.jacobian(u->dynamics(x,u,p,t), u)
-    C = ForwardDiff.jacobian(x->measurement(x,u,p,t), x)
+    if Ajac === nothing
+        Ajac = (x,u,p,t) -> ForwardDiff.jacobian(x->dynamics(x,u,p,t), x)
+    end
+    if Cjac === nothing
+        Cjac = (x,u,p,t) -> ForwardDiff.jacobian(x->measurement(x,u,p,t), x)
+    end
+    A = Ajac(x,u,p,t)
+    B = zeros(nx, nu) # This one is never needed
+    C = Cjac(x,u,p,t)
     D = zeros(ny, nu) # This one is never needed
     kf = KalmanFilter(A,B,C,D,R1,R2,d0; p, α, check)
-    return ExtendedKalmanFilter(kf, dynamics, measurement)
+    return ExtendedKalmanFilter(kf, dynamics, measurement, Ajac, Cjac)
+end
+
+function ExtendedKalmanFilter(kf, dynamics, measurement; Ajac = nothing, Cjac = nothing)
+    if Ajac === nothing
+        Ajac = (x,u,p,t) -> ForwardDiff.jacobian(x->dynamics(x,u,p,t), x)
+    end
+    if Cjac === nothing
+        Cjac = (x,u,p,t) -> ForwardDiff.jacobian(x->measurement(x,u,p,t), x)
+    end
+    return ExtendedKalmanFilter(kf, dynamics, measurement, Ajac, Cjac)
 end
 
 function Base.getproperty(ekf::EKF, s::Symbol) where EKF <: AbstractExtendedKalmanFilter
@@ -63,7 +81,7 @@ end
 
 function predict!(kf::AbstractExtendedKalmanFilter, u, p = parameters(kf), t::Integer = index(kf); R1 = get_mat(kf.R1, kf.x, u, p, t), α = kf.α)
     @unpack x,R = kf
-    A = ForwardDiff.jacobian(x->kf.dynamics(x,u,p,t), x)
+    A = kf.Ajac(x, u, p, t)
     kf.x = kf.dynamics(x, u, p, t)
     if α == 1
         kf.R = symmetrize(A*R*A') + R1
@@ -75,8 +93,8 @@ end
 
 function correct!(kf::AbstractExtendedKalmanFilter, u, y, p = parameters(kf), t::Integer = index(kf); R2 = get_mat(kf.R2, kf.x, u, p, t))
     @unpack x,R = kf
-    C = ForwardDiff.jacobian(x->kf.measurement(x,u,p,t), x)
-    e  = y .- kf.measurement(x,u,p,t)
+    C   = kf.Cjac(x, u, p, t)
+    e   = y .- kf.measurement(x, u, p, t)
     S   = symmetrize(C*R*C') + R2
     Sᵪ  = cholesky(S)
     K   = (R*C')/Sᵪ

--- a/src/ekf.jl
+++ b/src/ekf.jl
@@ -15,7 +15,7 @@ A nonlinear state estimator propagating uncertainty using linearization.
 
 The constructor to the extended Kalman filter takes dynamics and measurement functions, and either covariance matrices, or a [`KalmanFilter`](@ref). If the former constructor is used, the number of inputs to the system dynamics, `nu`, must be explicitly provided with a keyword argument.
 
-The filter will internally linearize the dynamics using ForwardDiff.
+By default, the filter will internally linearize the dynamics using ForwardDiff. User provided Jacobian functions can be provided as keyword arguments `Ajac` and `Cjac`. These functions should have the signature `(x,u,p,t)::AbstractMatrix` where `x` is the state, `u` is the input, `p` is the parameters, and `t` is the time.
 
 The dynamics and measurement function are on the following form
 ```

--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -85,7 +85,7 @@ end
 """
     prediction_errors!(res, f::AbstractFilter, u, y, p = parameters(f), λ = 1)
 
-Calculate the prediction errors and store the result in `res`. Similar to [`sse`](@ref), this funciton is useful for sum-of-squares optimization. In contrast to `sse`, this function returns the residuals themselves rather than their sum of squares. This is useful for Gauss-Newton style optimizers, such as [LeastSquaresOptim.LevenbergMarquardt](https://github.com/matthieugomez/LeastSquaresOptim.jl).
+Calculate the prediction errors and store the result in `res`. Similar to [`sse`](@ref), this function is useful for sum-of-squares optimization. In contrast to `sse`, this function returns the residuals themselves rather than their sum of squares. This is useful for Gauss-Newton style optimizers, such as [LeastSquaresOptim.LevenbergMarquardt](https://github.com/matthieugomez/LeastSquaresOptim.jl).
 
 # Arguments:
 - `res`: A vector of length `ny*length(y)`. Note, for each datapoint in `u` and `u`, there are `ny` outputs, and thus `ny` residuals.
@@ -112,7 +112,7 @@ end
 """
     ll = loglik(filter, u, y, p=parameters(filter))
 
-Calculate loglikelihood for entire sequences `u,y`
+Calculate log-likelihood for entire sequences `u,y`
 """
 function loglik(f::AbstractFilter,u,y,p=parameters(f))
     reset!(f)


### PR DESCRIPTION
The default is still to provide automatic Jacobians using ForwardDiff, but with this PR the user can provide their own Jacobian functions.