### PR TITLE
introduce optional non-unit sample interval

### DIFF
--- a/ext/LowLevelParticleFiltersDistributionsExt.jl
+++ b/ext/LowLevelParticleFiltersDistributionsExt.jl
@@ -70,7 +70,7 @@ end
 LowLevelParticleFilters.extended_logpdf(d::Distribution, args...) = Distributions.logpdf(d, args...)
 
 # resolve ambiguity
-Base.@propagate_inbounds function LowLevelParticleFilters.propagate_particles!(pf::LowLevelParticleFilters.ParticleFilter, u, p, t::Int, d::Distributions.Sampleable=pf.dynamics_density)
+Base.@propagate_inbounds function LowLevelParticleFilters.propagate_particles!(pf::LowLevelParticleFilters.ParticleFilter, u, p, t::Real, d::Distributions.Sampleable=pf.dynamics_density)
     f = pf.dynamics
     x,xp = pf.state.x, pf.state.xprev
     VecT = eltype(pf.state.x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,6 +131,7 @@ function rk4(f::F, Ts0; supersample::Integer = 1) where {F}
                 f3 = f(x + Ts / 2 * f2, u, p, t + Ts / 2)
                 f4 = f(x + Ts * f3, u, p, t + Ts)
                 x += Ts / 6 * (f1 + 2 * f2 + 2 * f3 + f4)
+                t += Ts
             end
             return x
         end


### PR DESCRIPTION
This changes the default start time of filters from `t = 1` to `t = 0`. Most use cases should not notice this change, but when dynamics explicitly depends on time and the default time stepping in the filer is used, there will be a 1 time unit shift.