### PR TITLE
hot-fix: Diagonal weight W in prediction_errors()

### DIFF
--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -181,7 +181,8 @@ function prediction_errors!(res, f::AbstractFilter, u, y, p=parameters(f), λ=1;
     else
         length(res) == N*ny ||
         error("Residual vector length must be N*ny")
-        W = sqrt(λ)  # only used in non-loglik branch
+        λ_diag = (ndims(λ) == 2) ? λ.diag : λ
+        W = sqrt.(λ_diag)  # only used in non-loglik branch
     end
     # index ranges
     idx = 0


### PR DESCRIPTION
The documentation suggests using λ = Diagonal(1 ./ (mag.^2)). 
However, the implementation [res[inds] .= W .* e] fails with a DimensionMismatch