### PR TITLE
Return (ll, lls, rest) from update!(::IMM, ...)

### DIFF
--- a/src/imm.jl
+++ b/src/imm.jl
@@ -191,7 +191,7 @@ end
 
 
 """
-    update!(imm::IMM, u, y, p, t; correct_kwargs = (;), predict_kwargs = (;), interact = true)
+    ll, lls, rest = update!(imm::IMM, u, y, p, t; correct_kwargs = (;), predict_kwargs = (;), interact = true)
 
 The combined udpate for an [`IMM`](@ref) filter performs the following steps:
 1. Correct each model with the measurements `y` and control input `u`.
@@ -205,13 +205,18 @@ This differs slightly from the udpate step of other filters, where at the end of
 - `correct_kwargs`: An optional named tuple of keyword arguments that are sent to [`correct!`](@ref).
 - `predict_kwargs`: An optional named tuple of keyword arguments that are sent to [`predict!`](@ref).
 - `interact`: Whether or not to run the interaction step.
+
+# Returns
+The same three-tuple as [`correct!(imm::IMM, ...)`](@ref): the sum of model
+log-likelihoods, the vector of individual model log-likelihoods, and an
+array of the remaining return values from each model's `correct!`.
 """
 function update!(imm::IMM, u, y, args...; correct_kwargs = (;), predict_kwargs = (;), interact = imm.interact)
-    ll, rest = correct!(imm, u, y, args...; correct_kwargs...)
+    ll, lls, rest = correct!(imm, u, y, args...; correct_kwargs...)
     combine!(imm)
     interact && interact!(imm)
     predict!(imm, u, args...; predict_kwargs...)
-    ll, rest
+    ll, lls, rest
 end
 
 (imm::IMM)(args...; kwargs...) = update!(imm::IMM, args...; kwargs...)

--- a/test/test_imm.jl
+++ b/test/test_imm.jl
@@ -122,4 +122,19 @@ x,u,y = simulate(imm, T, du) # Simulate the IMM
 
 sol = forward_trajectory(imm, u, y) # Forward trajectory
 
+## update! return value =======================================================
+# Regression test: update!(::IMM, ...) must return (ll, lls, rest) matching
+# correct!(::IMM, ...), not the 2-tuple it used to silently produce.
+kf1 = KalmanFilter(_A, _B, _C, 0, eye(nx), R2, d0)
+kf2 = KalmanFilter(_A, _B, _C, 0, eye(nx), R2, d0)
+imm_ret = IMM([kf1,kf2], [0.5 0.5; 0.5 0.5], [0.5,0.5])
+reset!(imm_ret)
+ret = update!(imm_ret, u[1], y[1])
+@test length(ret) == 3
+ll_u, lls_u, rest_u = ret
+@test ll_u isa Real
+@test lls_u isa AbstractVector && length(lls_u) == 2
+@test rest_u isa AbstractVector && length(rest_u) == 2
+@test ll_u ≈ log(sum(exp, lls_u .+ log.([0.5, 0.5])))
+
 plot(sol, plotx = true, plotxt=true, plotu=true, ploty=true, plotyh=true, plotyht=true, plote=true, plotR=true, plotRt=true)


### PR DESCRIPTION
## Summary
- `correct!(::IMM, ...)` returns the 3-tuple `(ll, lls, rest)` (summed log-likelihood, per-model log-likelihoods, and the array of per-model `correct!` returns).
- `update!(::IMM, ...)` was unpacking only two of those, so Julia's positional destructuring silently assigned `lls` to a local named `rest` and dropped the real `rest` array. Callers saw a mislabelled 2-tuple.
- Fix: unpack and return all three. Update the docstring. Add a regression test in `test/test_imm.jl`.

## Why
Anyone relying on `update!`'s second return value would have received the per-model log-likelihood vector while assuming it was the per-model `correct!` return array, with no error. This brings `update!` in line with the documented `correct!` shape.

## Test plan
- [x] New regression test in `test/test_imm.jl` checks that `update!` returns a 3-tuple `(ll, lls, rest)` with sensible shapes and that `ll` matches the closed-form `logsumexp(lls + log(μP))`.
- [x] Full test suite still passes for IMM (488/488 in the local run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)