### PR TITLE
Smoother: evaluate A/C at the right time for time-varying KalmanFilter

### DIFF
--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -15,7 +15,9 @@ function smooth(sol::KalmanFilteringSolution, kf::KalmanFilter, u::AbstractVecto
     xT[end]      = xt[end]      |> copy
     RT[end]      = Rt[end]      |> copy
     for t = T-1:-1:1
-        C     = Rt[t]*get_mat(kf.A, xT[t+1], u[t+1], p, (t+1-1)*kf.Ts)'/cholesky(Symmetric(R[t+1]))
+        # A_t propagates step t -> t+1, matching the forward pass which
+        # evaluates it at time (t-1)*Ts (so the 3-D array form returns A[:,:,t]).
+        C     = Rt[t]*get_mat(kf.A, xt[t], u[t], p, (t-1)*kf.Ts)'/cholesky(Symmetric(R[t+1]))
         xT[t] = xt[t] .+ C*(xT[t+1] .- x[t+1])
         RT[t] = Rt[t] .+ symmetrize(C*(RT[t+1] .- R[t+1])*C')
     end
@@ -51,14 +53,10 @@ function smooth_mbf(sol::KalmanFilteringSolution, kf::AbstractKalmanFilter=sol.f
     λ̂[end] = zero(xt[end])
     r = similar(λ̂)
     for t = T:-1:1
-        ti = ((t+1)-1)*kf.Ts
-        # if t < T
-        #     F = get_A(kf, xT[t+1], u[t+1], p, ti) 
-        #     H = get_C(kf, xT[t+1], u[t+1], p, ti)
-        # else
-            F = get_A(kf, xt[t], u[t], p, ti) # NOTE: may be wrong state here, xT[t+1]?
-            H = get_C(kf, xt[t], u[t], p, ti)
-        # end
+        # The measurement matrix used at step t is evaluated at the same
+        # time as the forward pass uses for the correction at step t.
+        ti_H = (t-1)*kf.Ts
+        H = get_C(kf, xt[t], u[t], p, ti_H)
         if !isassigned(sol.K, t)
             xT[t] = xt[t]
             RT[t] = Rt[t]
@@ -77,6 +75,10 @@ function smooth_mbf(sol::KalmanFilteringSolution, kf::AbstractKalmanFilter=sol.f
         λ̃[t] = -HTS*sol.e[t] + C'λ̂[t] # Wikipedia wrong here, it should be residual instead of measurement
         Λ̃[t] = HTS*H + C'Λ̂[t]*C
         if t > 1
+            # The backward propagation λ̂[t-1] = F'*λ̃[t] uses the transition
+            # from step t-1 to step t. The forward pass evaluated A there
+            # at time (t-2)*Ts (so the 3-D array form returns A[:,:,t-1]).
+            F = get_A(kf, xt[t-1], u[t-1], p, (t-2)*kf.Ts)
             λ̂[t-1] = F'*λ̃[t]
             Λ̂[t-1] = F'Λ̃[t]*F
         end
@@ -96,8 +98,8 @@ function smooth_mbf(sol::KalmanFilteringSolution, kf::AbstractKalmanFilter=sol.f
     KalmanSmoothingSolution(sol, xT, RT),ll,λ̃,λ̂,r
 end
 
-get_A(kf::KalmanFilter, x, u, p, t) = kf.A
-get_C(kf::KalmanFilter, x, u, p, t) = kf.C
+get_A(kf::KalmanFilter, x, u, p, t) = get_mat(kf.A, x, u, p, t)
+get_C(kf::KalmanFilter, x, u, p, t) = get_mat(kf.C, x, u, p, t)
 
 function smooth(pf::AbstractParticleFilter, M, u, y, p=parameters(pf))
     sol = forward_trajectory(pf, u, y, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,11 @@ end
     include("test_imm.jl")
 end
 
+@testset "smoother time-varying" begin
+    @info "Testing smoother with time-varying A"
+    include("test_smoother_timevarying.jl")
+end
+
 @testset "parameters" begin
     @info "Testing parameters"
     include("test_parameters.jl")

--- a/test/test_smoother_timevarying.jl
+++ b/test/test_smoother_timevarying.jl
@@ -1,0 +1,73 @@
+# Regression test for the RTS / MBF smoothers when A is time-varying.
+# The forward pass evaluates A at time (t-1)*Ts so that the 3-D-array form
+# returns A[:,:,t] (transition from step t to t+1). The smoother must use
+# the SAME A_t to invert; a previous bug used time t*Ts (i.e. A[:,:,t+1]),
+# which only happened to work when A was constant.
+
+using LowLevelParticleFilters, LinearAlgebra, Random, Test
+import LowLevelParticleFilters: SimpleMvNormal
+
+@testset "smoother with 3-D time-varying A" begin
+    Random.seed!(123)
+    nx, nu, ny = 2, 1, 1
+    T = 30
+
+    # A_seq[:,:,t] is the transition from step t to t+1
+    A_seq = zeros(nx, nx, T)
+    for k = 1:T
+        θ = 0.05 * k
+        A_seq[:,:,k] = [cos(θ) -sin(θ); sin(θ) cos(θ)] .* 0.97
+    end
+    B = reshape([0.0, 1.0], nx, nu)
+    C = [1.0 0.0]
+    R1 = 0.01 * I(nx)
+    R2 = 0.1 * I(ny)
+    d0 = SimpleMvNormal(zeros(nx), Matrix(1.0I, nx, nx))
+
+    kf = KalmanFilter(A_seq, B, C, 0, R1, R2, d0)
+
+    # Simulate a trajectory using the same time-varying A so the smoother is
+    # solving the right problem.
+    Random.seed!(1)
+    x_true = [zeros(nx) for _ in 1:T+1]
+    x_true[1] = rand(d0)
+    u_seq = [randn(nu) for _ in 1:T]
+    y_seq = Vector{Vector{Float64}}(undef, T)
+    for t = 1:T
+        w = sqrt(0.01) * randn(nx)
+        x_true[t+1] = A_seq[:,:,t]*x_true[t] + B*u_seq[t] + w
+        v = sqrt(0.1) * randn(ny)
+        y_seq[t] = C*x_true[t] + v
+    end
+
+    sol = forward_trajectory(kf, u_seq, y_seq)
+    xT, RT, ll = smooth(sol, kf, u_seq, y_seq)
+
+    # Reference smoother: a plain hand-rolled RTS recursion over A_seq.
+    xt = sol.xt
+    Rt = sol.Rt
+    x_pred = sol.x
+    R_pred = sol.R
+    xT_ref = similar(xt)
+    RT_ref = similar(Rt)
+    xT_ref[end] = copy(xt[end])
+    RT_ref[end] = copy(Rt[end])
+    for t = T-1:-1:1
+        Ck = Rt[t] * A_seq[:,:,t]' / cholesky(Symmetric(R_pred[t+1]))
+        xT_ref[t] = xt[t] + Ck*(xT_ref[t+1] - x_pred[t+1])
+        RT_ref[t] = Rt[t] + Ck*(RT_ref[t+1] - R_pred[t+1])*Ck'
+        RT_ref[t] = 0.5*(RT_ref[t] + RT_ref[t]')
+    end
+
+    for t = 1:T
+        @test xT[t] ≈ xT_ref[t] rtol=1e-8
+        @test RT[t] ≈ RT_ref[t] rtol=1e-8
+    end
+
+    # MBF smoother should produce the same result up to numerical noise.
+    ssol_mbf, _, _, _, _ = LowLevelParticleFilters.smooth_mbf(sol, kf, u_seq, y_seq)
+    for t = 1:T
+        @test ssol_mbf.xT[t] ≈ xT_ref[t] rtol=1e-6
+        @test ssol_mbf.RT[t] ≈ RT_ref[t] rtol=1e-6
+    end
+end


### PR DESCRIPTION
## Summary
The Kalman smoothers were evaluating the dynamics matrix at the wrong time index, which only mattered for time-varying `A`/`C`.

- The forward pass evaluates `A` at time `(t-1)*Ts` so the 3-D-array form returns `A[:,:,t]` — the transition from step `t` to step `t+1`.
- The backward smoothers (`smooth` and `smooth_mbf`) evaluated `A` at time `t*Ts`, which returns `A[:,:,t+1]` — the transition from `t+1` to `t+2`.
- For constant `A` this was invisible; for a 3-D time-varying `A` (or a state-/input-dependent `A` function) the smoothed estimates were wrong.

## Changes
- `src/smoothing.jl`:
  - `smooth`: RTS gain now uses `get_mat(kf.A, xt[t], u[t], p, (t-1)*Ts)`.
  - `smooth_mbf`: `H` is evaluated at `(t-1)*Ts` (step-`t` correction); the backward-propagation matrix `F` is evaluated at `(t-2)*Ts` (step `t-1 -> t` transition), matching the forward-pass convention.
  - `get_A` / `get_C` helpers used by `smooth_mbf` now delegate to `get_mat`, so they handle 3-D arrays and function-form dynamics consistently with the rest of the code.
- `test/test_smoother_timevarying.jl`: builds a `KalmanFilter` over a 3-D `A_seq` and compares both smoothers against a hand-rolled RTS pass over the same `A_seq`. 120/120 pass.

## Why
Anyone using a 3-D time-varying `A` (e.g. `A = randn(nx, nx, T)`) with `smooth` or `smooth_mbf` was silently getting the wrong matrix at every backward step. The fix locks the time-axis convention down with a regression test.

## Test plan
- [x] New `test/test_smoother_timevarying.jl` passes (120/120).
- [x] Existing `smooth` vs `smooth_mbf` agreement test in `runtests.jl` (lines ~290-294) still passes.
- [ ] CI green.

Pre-existing failure note: `test_mukf.jl:371` (a MUKF allocation count check) currently fails on master; it is unrelated to this PR and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)