### PR TITLE
get_mat: clear error for 3-D arrays with non-integer time

### DIFF
--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -15,7 +15,14 @@ end
 
 @inline get_mat(A::Nothing,x,u,p,t) = 0
 @inline get_mat(A::Union{AbstractMatrix, Number},x,u,p,t) = A
-@inline get_mat(A::AbstractArray{<:Any, 3},x,u,p,t) = @view A[:,:,t+1]
+@inline get_mat(A::AbstractArray{<:Any, 3},x,u,p,t::Integer) = @view A[:,:,t+1]
+@inline function get_mat(A::AbstractArray{<:Any, 3}, x, u, p, t::Real)
+    isinteger(t) || throw(ArgumentError(
+        "get_mat: a 3-D time-varying matrix is indexed by integer step but got t = $t. " *
+        "Pass `A` as a function `A(x, u, p, t)` if the time-varying matrix must be " *
+        "evaluated at non-integer time points (e.g. for `Ts != 1`)."))
+    @view A[:,:, Int(t)+1]
+end
 @inline get_mat(A::Function,x,u,p,t) = A(x,u,p,t)
 
 """
@@ -25,7 +32,7 @@ end
 
 This is a helper function that makes it possible to supply any of
 - A matrix
-- A "time varying" matrix where time is in the last dimension (the array will be indexed at `t+1` since `t` starts at 0)
+- A "time varying" matrix where time is in the last dimension (the array will be indexed at `t+1` since `t` starts at 0). This form requires the sampling time `Ts == 1`; for non-unit `Ts`, use the function form below since the integer step index is otherwise ambiguous.
 - A function of `x,u,p,t` that returns the matrix
 
 This is useful to implement things like

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -545,6 +545,11 @@ end
     include("test_imm.jl")
 end
 
+@testset "get_mat 3D time" begin
+    @info "Testing get_mat 3-D array time handling"
+    include("test_getmat_3d_time.jl")
+end
+
 @testset "parameters" begin
     @info "Testing parameters"
     include("test_parameters.jl")

--- a/test/test_getmat_3d_time.jl
+++ b/test/test_getmat_3d_time.jl
@@ -1,0 +1,52 @@
+# Regression test: get_mat for a 3-D time-varying matrix should
+# (a) work for integer-valued time
+# (b) error with a clear message for non-integer time, instead of
+#     bubbling up a confusing index error from getindex.
+
+using LowLevelParticleFilters, LinearAlgebra, Test
+import LowLevelParticleFilters: SimpleMvNormal, get_mat
+
+@testset "get_mat 3-D array time arg" begin
+    T = 10
+    A = randn(2, 2, T)
+
+    # Integer time works.
+    @test get_mat(A, nothing, nothing, nothing, 0) == A[:, :, 1]
+    @test get_mat(A, nothing, nothing, nothing, 3) == A[:, :, 4]
+    # Real but integer-valued time works too (most call sites pass Float64).
+    @test get_mat(A, nothing, nothing, nothing, 0.0) == A[:, :, 1]
+    @test get_mat(A, nothing, nothing, nothing, 3.0) == A[:, :, 4]
+
+    # Non-integer time must produce a clear ArgumentError rather than
+    # whatever obscure failure `A[:,:,0.1+1]` would have raised.
+    err = try
+        get_mat(A, nothing, nothing, nothing, 0.1)
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    @test occursin("3-D", err.msg)
+    @test occursin("function", err.msg)
+end
+
+@testset "predict! with 3-D A and non-unit Ts errors clearly" begin
+    nx, nu, ny = 2, 1, 1
+    Tlen = 8
+    A_seq = randn(nx, nx, Tlen)
+    B = reshape([0.0, 1.0], nx, nu)
+    C = [1.0 0.0]
+    R1 = 0.01 * I(nx)
+    R2 = 0.1 * I(ny)
+    d0 = SimpleMvNormal(zeros(nx), Matrix(1.0I, nx, nx))
+
+    # Ts=1.0 with an integer-step index works (regression: previously
+    # also worked, but now the new method dispatch must not regress it).
+    kf_int = KalmanFilter(A_seq, B, C, 0, R1, R2, d0; Ts = 1.0)
+    @test_nowarn predict!(kf_int, [0.0])
+
+    # Ts=0.1 makes the second predict!'s time argument 0.1, which is
+    # not integer-valued and so must error.
+    kf_frac = KalmanFilter(A_seq, B, C, 0, R1, R2, d0; Ts = 0.1)
+    @test_nowarn predict!(kf_frac, [0.0])  # first call has t = 0.0, ok
+    @test_throws ArgumentError predict!(kf_frac, [0.0])  # t = 0.1, not ok
+end


### PR DESCRIPTION
## Summary
The 3-D-array branch of `get_mat` did `@view A[:,:, t+1]`, which silently assumed `t` was an integer. Every Kalman-style filter passes `t = index(kf) * kf.Ts`, so as soon as `Ts != 1`, this produced an opaque `MethodError` from `getindex`. The 3-D-array form was effectively undocumented to require `Ts == 1`.

## Changes
- `src/filtering.jl`: split the 3-D-array `get_mat` overload into an `Integer` fast path and a `Real` path that checks `isinteger(t)` and otherwise throws `ArgumentError` with a message pointing at the function form `A(x, u, p, t)`.
- Documented the `Ts == 1` constraint inline in the `get_mat` docstring.
- `test/test_getmat_3d_time.jl`: exercises both the success path (Int and integer-valued Float) and the error path (predict! with `Ts=0.1`).

## Why
Users who try to combine a 3-D time-varying matrix with `Ts != 1` now get a clear message that points at the workaround (use the function form), instead of a confusing index error far down the stack.

## Test plan
- [x] `test/test_getmat_3d_time.jl` passes locally (10/10).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)