### PR TITLE
Fix test numerical issues

### DIFF
--- a/test/test_constraint_handling.jl
+++ b/test/test_constraint_handling.jl
@@ -112,12 +112,12 @@ using Plots
             
             @test μ_tmm[2] > 0.0  # Mean should be positive
             @test μ_tmm[2] > μ[2]  # Mean should increase
-            @test issymmetric(Σ_tmm)
-            @test isposdef(Σ_tmm)
+            @test isapprox(Σ_tmm, Σ_tmm')
+            @test isposdef(Hermitian(Σ_tmm))
             @test Σ_tmm[2,2] < Σ[2,2]  # Variance should decrease due to truncation
 
             covplot(μ, Σ, mean=true, label="Original")
-            covplot!(μ_tmm, Σ_tmm, mean=true, label="Projected")
+            covplot!(μ_tmm, Hermitian(Σ_tmm), mean=true, label="Projected")
         end
         
         @testset "Monte Carlo verification - univariate" begin


### PR DESCRIPTION
The `issymmetric()` and `isposdef()` calls fails when I run tests locally. Updated the calls based on https://github.com/JuliaLang/LinearAlgebra.jl/issues/558

https://github.com/baggepinnen/LowLevelParticleFilters.jl/blob/master/test/test_mukf.jl#L368C5-L372C8 also gives a value much higher, like on CI for me, so this test also failed, but I didn't touch it.

Using Linux Mint with Julia 1.12.6.