### PR TITLE
Add more resample methods

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -144,7 +144,7 @@ If [MonteCarloMeasurements.jl](https://github.com/baggepinnen/MonteCarloMeasurem
 For a full usage example, see the benchmark section below or [example_lineargaussian.jl](https://github.com/baggepinnen/LowLevelParticleFilters.jl/blob/master/src/example_lineargaussian.jl)
 
 ### Resampling
-The particle filter will perform a resampling step whenever the distribution of the weights has become degenerate. The resampling is triggered when the *effective number of samples* is smaller than `pf.resample_threshold` ``\in [0, 1]``, this value can be set when constructing the filter. How the resampling is done is governed by `pf.resampling_strategy`, we currently provide `ResampleSystematic <: ResamplingStrategy` as the only implemented strategy. See https://en.wikipedia.org/wiki/Particle_filter for more info.
+The particle filter will perform a resampling step whenever the distribution of the weights has become degenerate. The resampling is triggered when the *effective number of samples* is smaller than `pf.resample_threshold` ``\in [0, 1]``, this value can be set when constructing the filter. How the resampling is done is governed by `pf.resampling_strategy`, and we currently provide `ResampleSystematic <: ResamplingStrategy`, `ResampleStratified <: ResamplingStrategy`, and `ResampleResidual <: ResamplingStrategy`. See https://en.wikipedia.org/wiki/Particle_filter for more info.
 
 # Particle Smoothing
 Smoothing is the process of finding the best state estimate given both past and future data. Smoothing is thus only possible in an offline setting. This package provides a particle smoother, based on forward filtering, backward simulation (FFBS), example usage follows:

--- a/src/LowLevelParticleFilters.jl
+++ b/src/LowLevelParticleFilters.jl
@@ -32,6 +32,8 @@ struct NullParameters end
 
 abstract type ResamplingStrategy end
 struct ResampleSystematic <: ResamplingStrategy end
+struct ResampleStratified <: ResamplingStrategy end
+struct ResampleResidual <: ResamplingStrategy end
 
 abstract type AbstractFilter end
 abstract type AbstractKalmanFilter <: AbstractFilter end

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -202,7 +202,7 @@ function predict!(pf::AuxiliaryParticleFilter, u, y1, p = parameters(pf), t = in
     measurement_equation!(pf.pf, u, y1, p, t, λ)
     s.w .+= λ # old w + new w, equivalent to old_we*new_we
     expnormalize!(s.w) # w used as buffer
-    j = resample(ResampleSystematic, s.w , s.j, s.bins)
+    j = resample(pf.resampling_strategy, s.w , s.j, s.bins)
     # reset_weights!(s) # We don't do this to keep λ and instead assign into w directly
     permute_with_buffer!(s.x, s.xprev, j)
     add_noise!(pf.pf)
@@ -224,7 +224,7 @@ function predict!(pf::AuxiliaryParticleFilter{<:AdvancedParticleFilter},u, y, p=
     measurement_equation!(pf.pf, u, y, p, t, λ)
     s.w .+= λ
     expnormalize!(s.w) # w used as buffer
-    j = resample(ResampleSystematic, s.w , s.j, s.bins)
+    j = resample(pf.resampling_strategy, s.w , s.j, s.bins)
     reset_weights!(s)
     # NOTE: this can be sped by letting the user implement `add_noise` and call that here, rather than propagating again
     propagate_particles!(pf.pf, u, j, p, t)# Propagate with noise and permutation

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -35,6 +35,86 @@ function resample(::Type{ResampleSystematic}, we, j, bins, M = length(we))
     return j
 end
 
+function resample(::Type{ResampleStratified}, we, j, bins, M = length(we))
+    N = length(we)
+    bins[1] = we[1]
+    for i = 2:N
+        bins[i] = bins[i-1] + we[i]
+    end
+
+    # u_i = (i - 1 + rand()) / M
+    bo = 1
+
+    for i = 1:M
+        u = (i - 1 + rand()) / M * bins[N]  # scale to sum(weights)
+
+        @inbounds for b = bo:N
+            if u < bins[b]
+                j[i] = b
+                bo = b
+                break
+            end
+        end
+    end
+
+    return j
+end
+
+function resample(::Type{ResampleResidual}, we, j, bins, M = length(we))
+    N = length(we)
+
+    wsum = zero(eltype(we))
+    @inbounds for i = 1:N
+        wsum += we[i]
+    end
+
+    inv_wsum = 1 / wsum
+
+    num = 0
+
+    @inbounds for i = 1:N
+        nw = we[i] * inv_wsum * M
+        cnt = floor(Int, nw)
+        bins[i] = nw - cnt   # store residual weight
+
+        for k = 1:cnt
+            num += 1
+            j[num] = i
+        end
+    end
+
+    if num == M
+        return j
+    end
+
+    rsum = zero(eltype(we))
+    @inbounds for i = 1:N
+        rsum += bins[i]
+    end
+
+    inv_rsum = 1 / rsum
+    @inbounds for i = 1:N
+        bins[i] *= inv_rsum
+    end
+
+    bins[1] = bins[1]
+    @inbounds for i = 2:N
+        bins[i] += bins[i-1]
+    end
+
+    @inbounds for m = (num + 1):M
+        u = rand()
+
+        for i = 1:N
+            if u < bins[i]
+                j[m] = i
+                break
+            end
+        end
+    end
+
+    return j
+end
 
 # """
 # There is probably lots of room for improvement here. All bins need not be formed in the beginning.

--- a/src/smoothing.jl
+++ b/src/smoothing.jl
@@ -120,7 +120,7 @@ function smooth(pf::AbstractParticleFilter, xf, wf, wef, ll, M, u, y, p=paramete
     df = dynamics_density(pf)
     @assert M <= N "Must extend cache size of bins and j to allow this"
     xb = Array{particletype(pf)}(undef,M,T)
-    j = resample(ResampleSystematic, wef[:,T], M)
+    j = resample(pf.resampling_strategy, wef[:,T], M)
     # @show Set(j)
     for i = 1:M
         xb[i,T] = xf[j[i], T]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,8 +85,8 @@ out = zeros(2, 10000)
         @test result ≈ x[1]
     end
 
-    @testset "resample" begin
-        @info "testing resample"
+    @testset "resample systematic" begin
+        @info "testing resample systematic"
         s = PFstate(10)
         @test effective_particles(s.we) ≈ 10
         logsumexp!(s.w, s.we)
@@ -103,6 +103,54 @@ out = zeros(2, 10000)
             @test maximum(j) <= 100
             @test minimum(j) >= 1
         end
+    end
+
+    @testset "resample correct proportions" begin
+        @info "testing resample correct proportions"
+
+        we = [0.1, 0.5, 0.1, 0.15, 0.15]
+        K = length(we)
+        R = 10000
+
+        function empirical_proportions(results, K)
+            counts = zeros(Int, K)
+            for draw in results
+                for i in draw
+                    counts[i] += 1
+                end
+            end
+            return counts ./ sum(counts)
+        end
+
+        results_systematic =
+            [resample(LowLevelParticleFilters.ResampleSystematic, we) for _ in 1:R]
+
+        results_stratified =
+            [resample(LowLevelParticleFilters.ResampleStratified, we) for _ in 1:R]
+
+        results_residual =
+            [resample(LowLevelParticleFilters.ResampleResidual, we) for _ in 1:R]
+
+        p_sys = empirical_proportions(results_systematic, K)
+        p_str = empirical_proportions(results_stratified, K)
+        p_res = empirical_proportions(results_residual, K)
+
+        tol = 0.02
+
+        @test isapprox(p_sys, we; atol=tol)
+        @test isapprox(p_str, we; atol=tol)
+        @test isapprox(p_res, we; atol=tol)
+    end
+
+    @testset "resample stratified" begin
+        @info "testing resample stratified"
+        # With these weights the 2nd and 3rd entry should always be idx 2
+        we = [0.1, 0.5, 0.1, 0.15, 0.15]
+        
+        results = [resample(LowLevelParticleFilters.ResampleStratified, we) for _ in 1:100]
+
+        @test all(r -> r[2] == 2, results)
+        @test all(r -> r[3] == 2, results)
     end
 
     @testset "static distributions" begin


### PR DESCRIPTION
Adds stratified and residual resampling. Updated the places in filtering and smoothing that used the hardcoded `ResampleSystematic` to refer to `pf.resampling_method`.

`resample(we::AbstractArray) = resample(ResampleSystematic,we)` is still hardcoded to `ResampleSystematic` but I think (?) it's only called like this in tests, so I didn't change it.

Fixes #279.